### PR TITLE
To allow for using the Fileshare as Connector

### DIFF
--- a/ctxal-sdk/Public/new-alImage.ps1
+++ b/ctxal-sdk/Public/new-alImage.ps1
@@ -42,7 +42,7 @@ function New-ALImage {
     [Parameter(Mandatory = $true)]$websession,
     [Parameter(Mandatory = $true)][string]$name,
     [Parameter(Mandatory = $false)][string]$description = "",
-    [Parameter(Mandatory = $true)][string]$connectorid,
+    [Parameter(Mandatory = $true)][AllowEmptyString()][string]$connectorid,
     [Parameter(Mandatory = $true)][string[]]$appids,
     [Parameter(Mandatory = $true)][string]$osrevid,
     [Parameter(Mandatory = $true)][string]$platrevid,


### PR DESCRIPTION
When using a Fileshare as a connector for an image the connector.id shouldn't have any data, and so the new-alimage should allow an emptystring as input. This was tested successfully.